### PR TITLE
Allow binding to another (non-default) interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ libc is not even 50 KB. that's easily usable even on the cheapest routers.
 command line options
 ------------------------
 
-    microsocks -1 -i listenip -p port -u user -P password -b bindaddr
+    microsocks -1 -i listenip -p port -u user -P password -b bindaddr -B bindiface
 
 all arguments are optional.
 by default listenip is 0.0.0.0 and port 1080.


### PR DESCRIPTION
SO_BINDTODEVICE seems to be a linux-specific API. what prevents you from using the ip address of the specified interface with the existing -b option?

The existing -b option only works when the specified IP is on the same interface as the default route interface. When machine have multiple interfaces and the bind-ip is not on the default interface, this options (`-B`) solves the problem.

It would be nice to listen on a different interface that the outgoing connections.

The problem is that if the IP address set by the -b option is on the default route, the default route will be used and not the specified interface.

i can't merge this PR as-is, because it would break build on solaris, *BSD, and OSX